### PR TITLE
Switch the doc to ASCIIDOC 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,11 @@
+# Hyperledger Composer
+:toc:
+
+## Intro
+
+A collection of useful tools and utilities when working with Hyperledger Composer.
+
+include::packages/composer-protobuf/README.adoc[]
+include::packages/fabric-dev-servers/README.adoc[]
+include::packages/node-red-contrib-composer/README.adoc[]
+

--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,7 @@
 A collection of useful tools and utilities when working with Hyperledger Composer.
 
 include::packages/composer-protobuf/README.adoc[]
-include::packages/fabric-dev-servers/README.adoc[]
-include::packages/node-red-contrib-composer/README.adoc[]
 
+include::packages/fabric-dev-servers/README.adoc[]
+
+include::packages/node-red-contrib-composer/README.adoc[]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,0 @@
-# Hyperledger Composer
-Collection of useful tools and utilities when working with Hyperledger Composer
-
-- [composer-protobuf](./packages/composer-protobuf/README.md) is a utility that maps from Composer models to protobufs
-- [fabric-dev-servers](./packages/fabric-dev-servers/README.md) is a set of scripts to download and stand-up a local Hyperledger Fabric Instance. Letting you develop using Composer but with a real fabric.
-- [node-red-contrib-hyperledger-composer](./packages/node-red-contrib-composer/README.md) is a set of node-red nodes to interact with Composer. Great for IoT solutions.
-ww

--- a/packages/composer-protobuf/README.adoc
+++ b/packages/composer-protobuf/README.adoc
@@ -1,11 +1,12 @@
-# Hyperledger Composer Protobuf
+
+## Hyperledger Composer Protobuf
 
 This module converts Google Protobuf files into Hyperledger Composer models.
 It is currently experimental and has a number of limitations.
 
 Despite these limitations it is a useful tool to convert protobuf data definitions from an existing project to bootstrap a new Composer project. After conversion the generated Composer models will need to be edited to convert some Concepts into Assets, Participants or Transactions.
 
-## Approach
+### Approach
 
 All protobuf types with fields are converted to Composer `Concepts`.
 
@@ -23,30 +24,30 @@ Default values are supported for Composer primitive types only.
 
 Enumerations are converted.
 
-### Nested Types
+#### Nested Types
 
 Composer does not support type nesting, so all types in a protobuf package are put in the same Composer namespace.
 
-### Namespaces
+#### Namespaces
 
 A Composer file has a single namespace. The namespace of the Composer model is set to the namespace of the last type processed in the protobuf file.
 
-### Imports
+#### Imports
 
 The converter does not correctly resolve protobuf imports. If your protobuf files use imports some types may be missing from the generated Composer model.
 
-## Usage
+### Usage
 
-### Install node
+#### Install node
 Go the composer-protobuf directory and run below command:
 `npm install`
 
-### Command Line
+#### Command Line
 
 You can batch convert a set of `.proto` files under a root directory by running:
 
 `node ./lib/protobuf.js -i <inputDir> -o <outputDir>`
 
-### APIs
+#### APIs
 
 You can use the `ProtobufConverter` class to convert a single `.proto` file to a single Composer model file, or use the `ProtobufBatchConverter` class to convert all `.proto` files beneath a directory.

--- a/packages/fabric-dev-servers/README.adoc
+++ b/packages/fabric-dev-servers/README.adoc
@@ -1,13 +1,14 @@
-# fabric-dev-servers
+
+## fabric-dev-servers
 
 This repository contains a number of helper scripts to start up a Hyperledger Fabric v1.0
 network for development purposes. You can use the Hyperledger Fabric network created by these scripts to quickly deploy Blockchain business networks built using Hyperledger Composer, and test applications that depend on a running network.
 
 This package is also available inside the `composer-data` directory that is created via the [local installer] for Hyperledger Composer: [Installing and running Hyperledger Composer Playground locally](https://hyperledger.github.io/composer/installing/using-playground-locally.html)
 
-# Usage
+.Usage
 
-## Step 1: Getting Hyperledger Fabric running
+### Getting Hyperledger Fabric running
 
 These scripts use bash and Docker. You must ensure that both bash and Docker are installed on the target system before running these scripts.
 
@@ -44,9 +45,9 @@ $ ./stopFabric.sh
 $ ./teardownFabric.sh
 ```
 
-## Script details
+### Script details
 
-### Downloading Hyperledger Fabric
+#### Downloading Hyperledger Fabric
 
 Issue from the `fabric-tools` directory:
 
@@ -54,7 +55,7 @@ Issue from the `fabric-tools` directory:
 $ ./downloadFabric.sh
 ```
 
-### Starting Hyperledger Fabric
+#### Starting Hyperledger Fabric
 
 Issue from the `fabric-tools` directory:
 
@@ -68,7 +69,7 @@ By default, this script will pause for 15 seconds to let Hyperledger Fabric star
 $ export FABRIC_START_TIMEOUT=30
 ```
 
-### Stop Hyperledger Fabric
+#### Stop Hyperledger Fabric
 
 Issue from the `fabric-tools` directory:
 
@@ -76,7 +77,7 @@ Issue from the `fabric-tools` directory:
 $ ./stop.sh
 ```
 
-### Create Hyperledger Composer Profile
+#### Create Hyperledger Composer Profile
 
 Issue from the `fabric-tools` directory:
 
@@ -86,7 +87,7 @@ $ ./createComposerProfile.sh
 
 Note: this create a Hyperledger Composer profile specifically to connect to the Hyperledger Fabric network that you have already started.
 
-### Teardown Hyperledger Fabric
+#### Teardown Hyperledger Fabric
 
 Issue from the `fabric-tools` directory:
 
@@ -94,13 +95,13 @@ Issue from the `fabric-tools` directory:
 $ ./teardownFabric.sh
 ```
 
-### Command Ordering
+#### Command Ordering
 
 This diagram should to clarify the order in which the scripts can be run:
 
 ![](CmdOrder.png).
 
-# Additional commands
+.Additional commands
 
 It can sometimes be needed to delete all existing containers and images
 

--- a/packages/node-red-contrib-composer/README.adoc
+++ b/packages/node-red-contrib-composer/README.adoc
@@ -1,12 +1,16 @@
-#node-red-contrib-hyperledger-composer
+
+## node-red-contrib-hyperledger-composer
+
 A set of nodes for interacting with Hyperledger Composer
 
-*Note : These node will only work if you are running node red locally. It won't work if you are using node red on bluemix.*
+NOTE: These node will only work if you are running node red locally. It won't work if you are using node red on bluemix.*
 
-##Hyperledger-Composer-Out
+### Hyperledger-Composer-Out
+
 A node red output node that allows you to create, update or delete assets or participants and submit transactions.
 
-###Example Usage
+#### Example Usage
+
 This example uses the Car Auction Sample Network that can be obtained from [here](https://github.com/hyperledger/composer-sample-networks/tree/master/packages/carauction-network)
 
 The Car Auction Sample, simulates a car auction. It has two kinds of participant. An Auctioneer, who is responsible for conducting the auction, and a member who can bid on cars in the auction.
@@ -26,23 +30,26 @@ In this example we will create a participant, the participant .
 
 5. Using the playground or command line you should now be able to see the participant that has been created.
 
-##Hyperledger-Composer-Mid
+### Hyperledger-Composer-Mid
+
 A node red mid flow node that allows you to create, retrieve, update, or delete assets and participants from a registry.
 
-###Example Usage
+#### Example Usage
+
 This example follows on from the above example. It will retrieve the participant that was created above.
- 
+
  1. Create a `hyperledger-composer-mid node`
- 
+
  2. Enter the `connection profile name`, `business network identifier`, `user Id`, and `user secret` on the `hyperledger-composer-mid node`.
- 
+
  3. Use an `inject node` and set it to use JSON and enter the following JSON
- 
- ```
+
+```
 {"modelName" : "org.acme.vehicle.auction.Member", "id" : "Joe-Blogs@org.acme.com"}
 ```
 
 4. Use a `debug node` to capture the output from the `hyperledger-composer-mid node`
 
-##Hyperledger-Composer-In
+### Hyperledger-Composer-In
+
 A node red input node that subscribes to events from a blockchain


### PR DESCRIPTION
There are many benefits for using Asciidoc over Markdown.
It is very similar to Markdown but allows using includes for instance.

This makes it easier to manage and easier to read for the users.

Github unfortunately does not render the includes yet but you can check it out when rendering the files locally in your browser using https://chrome.google.com/webstore/detail/asciidoctorjs-live-previe/iaalpfgpbocpdfblpnhhgllgbdbchmia 