### PR TITLE
Fixed package.json for node-red-contrib-composer so that it will conn…

### DIFF
--- a/packages/node-red-contrib-composer/package.json
+++ b/packages/node-red-contrib-composer/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.11",
   "description": "Hyperledger Composer nodes for node-red",
   "dependencies": {
-    "composer-client": "^0.16.0-0",
-    "composer-common": "^0.16.0-0"
+    "composer-client": "^0.19.0-0",
+    "composer-common": "^0.19.0-0"
   },
   "devDependencies": {
     "eslint": "^3.5.0"


### PR DESCRIPTION
…ect to hlfv11 with composer v0.19, fixing current connector undefined error preventing use of node-red-contrib-composer