### PR TITLE
up node red node composer version, fix resolve bug on retrieve node

### DIFF
--- a/packages/node-red-contrib-composer/nodes/hyperledger-composer.js
+++ b/packages/node-red-contrib-composer/nodes/hyperledger-composer.js
@@ -245,7 +245,11 @@ module.exports = function (RED) {
                         })
                         .then((result) => {
                             node.log('got participant');
-                            return serializer.toJSON(result);
+                            if (resolve) {
+                                return result;
+                            } else {
+                                return serializer.toJSON(result);
+                            }
                         })
                         .catch((error) => {
                             throw(error);

--- a/packages/node-red-contrib-composer/package.json
+++ b/packages/node-red-contrib-composer/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.14",
   "description": "Hyperledger Composer nodes for node-red",
   "dependencies": {
-    "composer-admin": "^0.19.0-0",
-    "composer-client": "^0.19.0-0",
-    "composer-common": "^0.19.0-0",
+    "composer-admin": "^0.20.7",
+    "composer-client": "^0.20.7",
+    "composer-common": "^0.20.7",
     "formidable": "1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The current Node-RED nodes do not work with the latest Composer. 

Also when retrieve a resource, if resolve relationship is checked, the node throw an error.