### PR TITLE
[fabric-dev-servers] replace static bash's path in shebang by lookup in $PATH via env

### DIFF
--- a/packages/fabric-dev-servers/createComposerProfile.sh
+++ b/packages/fabric-dev-servers/createComposerProfile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/createPeerAdminCard.sh
+++ b/packages/fabric-dev-servers/createPeerAdminCard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/downloadFabric.sh
+++ b/packages/fabric-dev-servers/downloadFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv1/createComposerProfile.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv1/createComposerProfile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv1/createPeerAdminCard.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv1/createPeerAdminCard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv1/downloadFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv1/downloadFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv1/startFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv1/startFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv1/stopFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv1/stopFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv1/teardownFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv1/teardownFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv11/createComposerProfile.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv11/createComposerProfile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv11/createPeerAdminCard.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv11/createPeerAdminCard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv11/downloadFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv11/downloadFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv11/startFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv11/startFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv11/stopFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv11/stopFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv11/teardownFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv11/teardownFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv12/createComposerProfile.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv12/createComposerProfile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv12/createPeerAdminCard.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv12/createPeerAdminCard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv12/downloadFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv12/downloadFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv12/startFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv12/startFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv12/stopFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv12/stopFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/fabric-scripts/hlfv12/teardownFabric.sh
+++ b/packages/fabric-dev-servers/fabric-scripts/hlfv12/teardownFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/startFabric.sh
+++ b/packages/fabric-dev-servers/startFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/stopFabric.sh
+++ b/packages/fabric-dev-servers/stopFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/teardownAllDocker.sh
+++ b/packages/fabric-dev-servers/teardownAllDocker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fabric-dev-servers/teardownFabric.sh
+++ b/packages/fabric-dev-servers/teardownFabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
[downloadFabric.sh](https://github.com/hyperledger/composer-tools/blob/master/packages/fabric-dev-servers/downloadFabric.sh#L1) couldn't be executed on my [NixOS](https://nixos.org/) because `/bin/bash` doesn't exists on this OS. Also `/bin/bash` doesn't exists on broad range of other Unix systems.
The PR aims to solve the issue and keep up backward compatibility.