### PR TITLE
[fabric-dev-servers] fix stop fabic instruction

### DIFF
--- a/packages/fabric-dev-servers/README.md
+++ b/packages/fabric-dev-servers/README.md
@@ -109,7 +109,7 @@ $ export FABRIC_START_TIMEOUT=30
 Issue from the `fabric-tools` directory:
 
 ```
-$ ./stop.sh
+$ ./stopFabric.sh
 ```
 
 ### Create Hyperledger Composer PeerAdmin card


### PR DESCRIPTION
Signed-off-by: Alexei Pastuchov <info@maximka.de>
`stop.sh` mentioned in [Stop Hyperledger Fabric](../blob/master/packages/fabric-dev-servers/README.md#stop-hyperledger-fabric) doesn't exists.
It should be replaced by `stopFabric.sh`.